### PR TITLE
fix x-forwarded-host

### DIFF
--- a/src/proxy-client.spec.ts
+++ b/src/proxy-client.spec.ts
@@ -118,7 +118,7 @@ describe('ProxyClient', () => {
 
       expect(receivedHeaders['x-forwarded-for']).toBeDefined();
       expect(receivedHeaders['x-forwarded-proto']).toBeDefined();
-      expect(receivedHeaders['x-forwarded-host']).toBeDefined();
+      expect(receivedHeaders['x-forwarded-host']).toBe('localhost:3000');
     });
 
     test('should modify headers via modifyHeaders callback', async () => {

--- a/src/proxy-client.ts
+++ b/src/proxy-client.ts
@@ -52,6 +52,7 @@ export class ProxyClient {
           headers[key] = Array.isArray(value) ? value.join(', ') : value;
         }
       }
+      const host = headers.host || '';
 
       // Remove host header to avoid conflicts
       delete headers.host;
@@ -63,7 +64,7 @@ export class ProxyClient {
       const forwarded = headers['x-forwarded-for'] || req.socket.remoteAddress || '';
       modifiedHeaders['x-forwarded-for'] = forwarded;
       modifiedHeaders['x-forwarded-proto'] = 'https' in req.socket ? 'https' : 'http';
-      modifiedHeaders['x-forwarded-host'] = headers.host || '';
+      modifiedHeaders['x-forwarded-host'] = host;
 
       // Prepare request body if present
       let body: Buffer | undefined;


### PR DESCRIPTION
sets x-forwarded-host from the original host header.\n\ntest: npx vitest run src/proxy-client.spec.ts